### PR TITLE
refactor(error): improve error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +33,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+dependencies = [
+ "backtrace",
 ]
 
 [[package]]
@@ -231,6 +255,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "base64"
@@ -1100,6 +1139,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1440,6 +1485,7 @@ checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 name = "kindelia"
 version = "0.1.5"
 dependencies = [
+ "anyhow",
  "assert_cmd",
  "clap 4.0.22",
  "clap_complete",
@@ -1692,6 +1738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1781,6 +1836,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -2471,6 +2535,12 @@ dependencies = [
  "rustc_version",
  "syn",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc-hex"

--- a/kindelia/Cargo.toml
+++ b/kindelia/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = "1.0"
 
 # Events API
 tokio = { version = "1.19.1", features = ["sync"] }
-
+anyhow = { version = "1.0.66", features = ["backtrace"] }
 
 [dev-dependencies]
 assert_cmd = "1.0.1"

--- a/kindelia/src/config.rs
+++ b/kindelia/src/config.rs
@@ -87,10 +87,11 @@ where
         let value = Self::get_prop(config_values, &prop_path);
         if let Some(value) = value {
           return T::arg_from(value).map(|v| Some(v)).map_err(|e| {
-            anyhow!(format!(
+            anyhow!(
               "Could not convert value of '{}' into desired type: {}",
-              prop_path, e
-            ))
+              prop_path,
+              e
+            )
           });
         }
       }
@@ -108,13 +109,14 @@ where
     T: ArgumentFrom<toml::Value>,
   {
     let value = Self::get_prop(config_values, prop_path).ok_or_else(|| {
-      anyhow!(format!("Could not find prop '{}' in config file.", prop_path))
+      anyhow!("Could not find prop '{}' in config file.", prop_path)
     })?;
     T::arg_from(value).map_err(|e| {
-      anyhow!(format!(
+      anyhow!(
         "Could not convert value of '{}' into desired type: {}",
-        prop_path, e
-      ))
+        prop_path,
+        e
+      )
     })
   }
 
@@ -147,13 +149,13 @@ impl ArgumentFrom<String> for String {
 
 impl ArgumentFrom<String> for u32 {
   fn arg_from(t: String) -> anyhow::Result<Self> {
-    t.parse().map_err(|e| anyhow!(format!("Invalid integer: `{}`", e)))
+    t.parse().map_err(|e| anyhow!("Invalid integer: `{}`", e))
   }
 }
 
 impl ArgumentFrom<String> for u64 {
   fn arg_from(t: String) -> anyhow::Result<Self> {
-    t.parse().map_err(|e| anyhow!(format!("Invalid integer: `{}`", e)))
+    t.parse().map_err(|e| anyhow!("Invalid integer: `{}`", e))
   }
 }
 
@@ -163,12 +165,11 @@ impl ArgumentFrom<toml::Value> for u32 {
       toml::Value::Integer(i) => Ok(i as Self),
       toml::Value::String(s) => {
         let s = s.trim_start_matches("0x");
-        let num = u32::from_str_radix(s, 16).map_err(|e| {
-          anyhow!(format!("Invalid hexadecimal '{}': {}", s, e))
-        })?;
+        let num = u32::from_str_radix(s, 16)
+          .map_err(|e| anyhow!("Invalid hexadecimal '{}': {}", s, e))?;
         Ok(num)
       }
-      _ => Err(anyhow!(format!("Invalid integer '{}'", value))),
+      _ => Err(anyhow!("Invalid integer '{}'", value)),
     }
   }
 }
@@ -179,12 +180,11 @@ impl ArgumentFrom<toml::Value> for u64 {
       toml::Value::Integer(i) => Ok(i as u64),
       toml::Value::String(s) => {
         let s = s.trim_start_matches("0x");
-        let num = u64::from_str_radix(s, 16).map_err(|e| {
-          anyhow!(format!("Invalid hexadecimal '{}': {}", s, e))
-        })?;
+        let num = u64::from_str_radix(s, 16)
+          .map_err(|e| anyhow!("Invalid hexadecimal '{}': {}", s, e))?;
         Ok(num)
       }
-      _ => Err(anyhow!(format!("Invalid integer '{}'", value))),
+      _ => Err(anyhow!("Invalid integer '{}'", value)),
     }
   }
 }
@@ -202,7 +202,7 @@ impl ArgumentFrom<String> for bool {
     } else if t == "false" {
       Ok(false)
     } else {
-      Err(anyhow!(format!("Invalid boolean value: {}", t)))
+      Err(anyhow!("Invalid boolean value: {}", t))
     }
   }
 }
@@ -214,7 +214,7 @@ impl ArgumentFrom<String> for PathBuf {
         .ok_or_else(|| anyhow!("Could not find $HOME directory."))?;
       Ok(home_dir.join(path))
     } else {
-      PathBuf::from_str(&t).map_err(|_| anyhow!(format!("Invalid path: {}", t)))
+      PathBuf::from_str(&t).map_err(|_| anyhow!("Invalid path: {}", t))
     }
   }
 }
@@ -230,28 +230,25 @@ impl ArgumentFrom<toml::Value> for PathBuf {
 
 impl ArgumentFrom<toml::Value> for String {
   fn arg_from(t: toml::Value) -> anyhow::Result<Self> {
-    t.try_into()
-      .map_err(|_| anyhow!("Could not convert value into String".to_string()))
+    t.try_into().map_err(|_| anyhow!("Could not convert value into String"))
   }
 }
 
 impl ArgumentFrom<toml::Value> for Vec<String> {
   fn arg_from(t: toml::Value) -> anyhow::Result<Self> {
-    t.try_into()
-      .map_err(|_| anyhow!("Could not convert value into array".to_string()))
+    t.try_into().map_err(|_| anyhow!("Could not convert value into array"))
   }
 }
 
 impl ArgumentFrom<toml::Value> for bool {
   fn arg_from(t: toml::Value) -> anyhow::Result<Self> {
-    t.as_bool().ok_or_else(|| anyhow!(format!("Invalid boolean value: {}", t)))
+    t.as_bool().ok_or_else(|| anyhow!("Invalid boolean value: {}", t))
   }
 }
 
 impl ArgumentFrom<toml::Value> for kindelia_core::config::ApiConfig {
   fn arg_from(t: toml::Value) -> anyhow::Result<Self> {
-    t.try_into()
-      .map_err(|_| anyhow!("Could not convert value into array".to_string()))
+    t.try_into().map_err(|_| anyhow!("Could not convert value into array"))
   }
 }
 
@@ -262,7 +259,7 @@ pub fn arg_from_file_or_stdin<T: ArgumentFrom<String>>(
     FileInput::Path { path } => {
       // read from file
       let content = std::fs::read_to_string(&path).map_err(|err| {
-        anyhow!(format!("Cannot read from '{:?}' file: {}", path, err))
+        anyhow!("Cannot read from '{:?}' file: {}", path, err)
       })?;
       T::arg_from(content)
     }
@@ -271,7 +268,7 @@ pub fn arg_from_file_or_stdin<T: ArgumentFrom<String>>(
       let mut input = String::new();
       match std::io::stdin().read_line(&mut input) {
         Ok(_) => T::arg_from(input.trim().to_string()),
-        Err(err) => Err(anyhow!(format!("Could not read from stdin: {}", err))),
+        Err(err) => Err(anyhow!("Could not read from stdin: {}", err)),
       }
     }
   }

--- a/kindelia/src/files.rs
+++ b/kindelia/src/files.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use std::fmt::{Display, Formatter};
 use std::io::Read;
 use std::path::PathBuf;
@@ -40,19 +41,20 @@ impl Display for FileInput {
 
 // TODO: alternative that do not read the whole file immediately
 impl FileInput {
-  pub fn read_to_string(&self) -> Result<String, String> {
+  pub fn read_to_string(&self) -> anyhow::Result<String> {
     match self {
       FileInput::Path { path } => {
         // read from file
-        std::fs::read_to_string(path)
-          .map_err(|e| format!("Cannot read from '{:?}' file: {}", path, e))
+        std::fs::read_to_string(path).map_err(|e| {
+          anyhow!(format!("Cannot read from '{:?}' file: {}", path, e))
+        })
       }
       FileInput::Stdin => {
         // read from stdin
         let mut buff = String::new();
         std::io::stdin()
           .read_to_string(&mut buff)
-          .map_err(|e| format!("Could not read from stdin: {}", e))?;
+          .map_err(|e| anyhow!(format!("Could not read from stdin: {}", e)))?;
         Ok(buff)
       }
     }

--- a/kindelia/src/files.rs
+++ b/kindelia/src/files.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::Context;
 use std::fmt::{Display, Formatter};
 use std::io::Read;
 use std::path::PathBuf;
@@ -46,14 +46,14 @@ impl FileInput {
       FileInput::Path { path } => {
         // read from file
         std::fs::read_to_string(path)
-          .map_err(|e| anyhow!("Cannot read from '{:?}' cause: {}", path, e))
+          .context(format!("Cannot read from '{:?}'", path))
       }
       FileInput::Stdin => {
         // read from stdin
         let mut buff = String::new();
         std::io::stdin()
           .read_to_string(&mut buff)
-          .map_err(|e| anyhow!("Could not read from stdin: {}", e))?;
+          .context("Could not read from stdin")?;
         Ok(buff)
       }
     }

--- a/kindelia/src/files.rs
+++ b/kindelia/src/files.rs
@@ -45,16 +45,15 @@ impl FileInput {
     match self {
       FileInput::Path { path } => {
         // read from file
-        std::fs::read_to_string(path).map_err(|e| {
-          anyhow!(format!("Cannot read from '{:?}' file: {}", path, e))
-        })
+        std::fs::read_to_string(path)
+          .map_err(|e| anyhow!("Cannot read from '{:?}' cause: {}", path, e))
       }
       FileInput::Stdin => {
         // read from stdin
         let mut buff = String::new();
         std::io::stdin()
           .read_to_string(&mut buff)
-          .map_err(|e| anyhow!(format!("Could not read from stdin: {}", e)))?;
+          .map_err(|e| anyhow!("Could not read from stdin: {}", e))?;
         Ok(buff)
       }
     }

--- a/kindelia/src/main.rs
+++ b/kindelia/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod files;
 mod util;
 
+use anyhow::anyhow;
 use std::future::Future;
 use std::net::{SocketAddr, UdpSocket};
 use std::path::Path;
@@ -25,7 +26,7 @@ use kindelia_core::bits::ProtoSerialize;
 use kindelia_core::config::{ApiConfig, MineConfig, NodeConfig, UiConfig};
 use kindelia_core::net::{Address, ProtoComm};
 use kindelia_core::node::{
-  spawn_miner, Node, Transaction, TransactionError, MAX_TRANSACTION_SIZE,
+  spawn_miner, Node, Transaction, MAX_TRANSACTION_SIZE,
 };
 use kindelia_core::persistence::{
   get_ordered_blocks_path, SimpleFileStorage, BLOCKS_DIR,
@@ -40,7 +41,7 @@ use util::{
 use crate::cli::{GetStatsKind, NodeCleanBlocksCommand, NodeCleanCommand};
 use crate::util::init_config_file;
 
-fn main() -> Result<(), String> {
+fn main() -> anyhow::Result<()> {
   run_cli()
 }
 
@@ -58,7 +59,8 @@ macro_rules! resolve_cfg {
       .default_value($default)
       .build()
       .unwrap()
-      .resolve($cli, None)?
+      .resolve($cli, None)
+      .map_err(|e| anyhow!(e))?
   };
 
   // No default value
@@ -69,7 +71,8 @@ macro_rules! resolve_cfg {
       .default_value($default)
       .build()
       .unwrap()
-      .resolve($cli, None)?
+      .resolve($cli, None)
+      .map_err(|e| anyhow!(e))?
   };
 
   // Resolve config value with file
@@ -83,7 +86,8 @@ macro_rules! resolve_cfg {
       .default_value(|| Ok($default))
       .build()
       .unwrap()
-      .resolve($cli, $cfg)?
+      .resolve($cli, $cfg)
+      .map_err(|e| anyhow!(e))?
   };
 
   // No default value
@@ -94,21 +98,23 @@ macro_rules! resolve_cfg {
       .default_value(|| Err($default))
       .build()
       .unwrap()
-      .resolve($cli, $cfg)?
+      .resolve($cli, $cfg)
+      .map_err(|e| anyhow!(e))?
   };
 }
 
 // TODO: create own error with `thiserror`
 // TODO: separate file in `mod`'s?
 /// Parse CLI arguments and run
-pub fn run_cli() -> Result<(), String> {
+pub fn run_cli() -> anyhow::Result<()> {
   let parsed = Cli::parse();
   let default_base_path = || {
-    let home_dir = dirs::home_dir().ok_or("Could not find $HOME path")?;
-    Ok::<_, String>(home_dir.join(".kindelia"))
+    let home_dir =
+      dirs::home_dir().ok_or_else(|| anyhow!("Could not find $HOME path"))?;
+    Ok::<_, anyhow::Error>(home_dir.join(".kindelia"))
   };
   let default_node_data_path =
-    || Ok::<_, String>(default_base_path()?.join("state"));
+    || Ok::<_, anyhow::Error>(default_base_path()?.join("state"));
   let default_config_path = || Ok(default_base_path()?.join("kindelia.toml"));
   let default_api_url = || Ok("http://localhost:8000".to_string());
 
@@ -136,14 +142,12 @@ pub fn run_cli() -> Result<(), String> {
       let stmts = if encoded {
         statements_from_hex_seq(&code)?
       } else {
-        parser::parse_code(&code)?
+        parser::parse_code(&code).map_err(|e| anyhow!(e))?
       };
       match command {
         cli::CheckCommand::Transaction => {
           for ref stmt in stmts {
-            let transaction: Transaction = stmt
-              .try_into()
-              .map_err(|err: TransactionError| err.to_string())?;
+            let transaction: Transaction = stmt.try_into()?;
 
             // size printing
             {
@@ -180,15 +184,17 @@ pub fn run_cli() -> Result<(), String> {
       let skey: String = arg_from_file_or_stdin(secret_file.into())?;
       let skey = skey.trim();
       let skey = hex::decode(skey).map_err(|err| {
-        format!("Secret key should be valid hex string: {}", err)
+        anyhow!(format!("Secret key should be valid hex string: {}", err))
       })?;
-      let skey: [u8; 32] = skey
-        .try_into()
-        .map_err(|_| "Secret key should have exactly 64 bytes".to_string())?;
+      let skey: [u8; 32] = skey.try_into().map_err(|_| {
+        anyhow!("Secret key should have exactly 64 bytes".to_string())
+      })?;
       let code = load_code(file, encoded)?;
       let statement = match &code[..] {
         [stmt] => sign_code(stmt, &skey),
-        _ => Err("Input file should contain exactly one statement".to_string()),
+        _ => Err(anyhow!(
+          "Input file should contain exactly one statement".to_string()
+        )),
       }?;
       if encoded_output {
         println!("{}", hex::encode(statement.proto_serialized().to_bytes()));
@@ -205,7 +211,7 @@ pub fn run_cli() -> Result<(), String> {
       let stmts = if encoded {
         statements_from_hex_seq(&code)?
       } else {
-        parser::parse_code(&code)?
+        parser::parse_code(&code).map_err(|e| anyhow!(e))?
       };
       let results = run_on_remote(&api_url, stmts, f)?;
       for result in results {
@@ -218,7 +224,7 @@ pub fn run_cli() -> Result<(), String> {
       let stmts = if encoded {
         statements_from_hex_seq(&code)?
       } else {
-        parser::parse_code(&code)?
+        parser::parse_code(&code).map_err(|e| anyhow!(e))?
       };
       publish_code(&api_url, stmts, hosts)
     }
@@ -228,22 +234,22 @@ pub fn run_cli() -> Result<(), String> {
     }
     CliCommand::Get { kind, json } => {
       let prom = get_info(kind, json, &api_url);
-      run_async_blocking(prom)
+      run_async_blocking(prom).map_err(|e| anyhow!(e))
     }
     CliCommand::Init => {
       let path = default_config_path()?;
       eprintln!("Writing default configuration to '{}'...", path.display());
-      init_config_file(&path)?;
+      init_config_file(&path).map_err(|e| anyhow!(e))?;
       Ok(())
     }
     CliCommand::Node { command, data_dir, network_id } => {
-      let config = handle_config_file(&config_path)?;
+      let config = handle_config_file(&config_path).map_err(|e| anyhow!(e))?;
       let config = Some(&config);
 
       let network_id = resolve_cfg!(
         env = "KINDELIA_NETWORK_ID",
         prop = "node.network.network_id".to_string(),
-        no_default = "Missing `network_id` parameter.".to_string(),
+        no_default = anyhow!("Missing `network_id` parameter.".to_string()),
         cli_val = network_id,
         cfg = config,
       );
@@ -258,8 +264,11 @@ pub fn run_cli() -> Result<(), String> {
       .join(format!("{:#02X}", network_id));
 
       match command {
-        NodeCommand::Clean { command } => clean(&data_path, command)
-          .map_err(|err| format!("Could not clean kindelia's data: {}", err)),
+        NodeCommand::Clean { command } => {
+          clean(&data_path, command).map_err(|err| {
+            anyhow!(format!("Could not clean kindelia's data: {}", err))
+          })
+        }
         NodeCommand::Start { initial_peers, mine, json } => {
           // TODO: refactor config resolution out of command handling (how?)
 
@@ -299,9 +308,9 @@ pub fn run_cli() -> Result<(), String> {
           // Start
           let node_comm = init_socket().expect("Could not open a UDP socket");
           let initial_peers = initial_peers
-            .iter()
-            .map(|x| net::parse_address(x))
-            .collect::<Vec<_>>();
+            .into_iter()
+            .map(|x| net::parse_address(&x).map_err(|e| anyhow!(e)))
+            .collect::<Result<Vec<_>, anyhow::Error>>()?;
 
           let node_cfg = NodeConfig {
             network_id,
@@ -315,9 +324,7 @@ pub fn run_cli() -> Result<(), String> {
           };
 
           let api_config = Some(api_config);
-          start_node(node_cfg, api_config, node_comm, initial_peers);
-
-          Ok(())
+          start_node(node_cfg, api_config, node_comm, initial_peers)
         }
       }
     }
@@ -330,8 +337,8 @@ pub fn run_cli() -> Result<(), String> {
           .map(|s| s.strip_prefix("0x").unwrap_or(s))
           .map(hex::decode)
           .collect();
-        let data =
-          data.map_err(|err| format!("Invalid hex string: {}", err))?;
+        let data = data
+          .map_err(|err| anyhow!(format!("Invalid hex string: {}", err)))?;
         let nums = data.iter().map(|v| bytes_to_u128(v));
         for num in nums {
           if let Some(num) = num {
@@ -356,14 +363,14 @@ fn run_on_remote<T, P, F>(
   api_url: &str,
   stmts: Vec<ast::Statement>,
   f: F,
-) -> Result<T, String>
+) -> anyhow::Result<T>
 where
   F: FnOnce(ApiClient, Vec<HexStatement>) -> P,
   P: Future<Output = Result<T, String>>,
 {
   let stmts: Vec<HexStatement> = stmts.into_iter().map(|s| s.into()).collect();
-  let client = ApiClient::new(api_url, None).map_err(|e| e.to_string())?;
-  run_async_blocking(f(client, stmts))
+  let client = ApiClient::new(api_url, None)?;
+  run_async_blocking(f(client, stmts)).map_err(|e| anyhow!(e))
 }
 
 fn print_json_else<T: Serialize, F: Fn(T)>(
@@ -512,7 +519,7 @@ pub fn serialize_code(code: &str) {
   }
 }
 
-pub fn deserialize_code(content: &str) -> Result<(), String> {
+pub fn deserialize_code(content: &str) -> anyhow::Result<()> {
   let statements = statements_from_hex_seq(content)?;
   for statement in statements {
     println!("{}", statement)
@@ -523,7 +530,7 @@ pub fn deserialize_code(content: &str) -> Result<(), String> {
 pub fn sign_code(
   statement: &ast::Statement,
   skey: &[u8; 32],
-) -> Result<ast::Statement, String> {
+) -> anyhow::Result<ast::Statement> {
   let user = crypto::Account::from_private_key(skey);
   let hash = runtime::hash_statement(statement);
   let sign = user.sign(&hash);
@@ -533,7 +540,7 @@ pub fn sign_code(
     | ast::Statement::Run { sign, .. }
     | ast::Statement::Reg { sign, .. } => {
       if sign.is_some() {
-        return Err("Statement already has a signature.".to_string());
+        return Err(anyhow!("Statement already has a signature.".to_string()));
       }
     }
   };
@@ -541,20 +548,26 @@ pub fn sign_code(
   Ok(stat)
 }
 
-fn load_code(file: FileInput, encoded: bool) -> Result<Vec<ast::Statement>, String> {
+fn load_code(
+  file: FileInput,
+  encoded: bool,
+) -> anyhow::Result<Vec<ast::Statement>> {
   let code = file.read_to_string()?;
   handle_code(&code, encoded)
 }
 
-fn handle_code(code: &str, encoded: bool) -> Result<Vec<ast::Statement>, String> {
+fn handle_code(
+  code: &str,
+  encoded: bool,
+) -> anyhow::Result<Vec<ast::Statement>> {
   if encoded {
     statements_from_hex_seq(code)
   } else {
-    parser::parse_code(code)
+    parser::parse_code(code).map_err(|e| anyhow!(e))
   }
 }
 
-fn statements_from_hex_seq(txt: &str) -> Result<Vec<ast::Statement>, String> {
+fn statements_from_hex_seq(txt: &str) -> anyhow::Result<Vec<ast::Statement>> {
   txt
     .trim()
     .split(|c: char| c.is_whitespace())
@@ -562,27 +575,28 @@ fn statements_from_hex_seq(txt: &str) -> Result<Vec<ast::Statement>, String> {
     .collect()
 }
 
-fn statement_from_hex(hex: &str) -> Result<ast::Statement, String> {
-  let bytes = hex::decode(hex)
-    .map_err(|err| format!("Invalid hexadecimal '{}': {}", hex, err))?;
+fn statement_from_hex(hex: &str) -> anyhow::Result<ast::Statement> {
+  let bytes = hex::decode(hex).map_err(|err| {
+    anyhow!(format!("Invalid hexadecimal '{}': {}", hex, err))
+  })?;
   ast::Statement::proto_deserialized(&bytes_to_bitvec(&bytes))
-    .ok_or(format!("Failed to deserialize '{}'", hex))
+    .ok_or_else(|| anyhow!(format!("Failed to deserialize '{}'", hex)))
 }
 pub fn publish_code(
   api_url: &str,
   stmts: Vec<ast::Statement>,
   hosts: Vec<SocketAddr>,
-) -> Result<(), String> {
+) -> anyhow::Result<()> {
   // setup tokio runtime and unordered joinset (tasks).
-  let runtime = tokio::runtime::Runtime::new().map_err(|e| e.to_string())?;
+  let runtime = tokio::runtime::Runtime::new()?;
   let mut tasks = tokio::task::JoinSet::new();
 
-  let client = ApiClient::new(api_url, None).map_err(|e| e.to_string())?;
+  let client = ApiClient::new(api_url, None)?;
 
   let peer_urls: Vec<String> = if hosts.is_empty() {
     // obtain list of active peers known to "our" node.
     let prom = async move { client.get_peers::<NC>(false).await };
-    let peers = runtime.block_on(prom)?;
+    let peers = runtime.block_on(prom).map_err(|e| anyhow!(e))?;
     let mut urls: Vec<String> = peers
       .iter()
       .map(|p| match p.address {
@@ -611,7 +625,7 @@ pub fn publish_code(
   for peer_url in peer_urls.into_iter() {
     // these are move'd into the spawned task, so they must be
     // created for each iteration.
-    let client = ApiClient::new(peer_url, None).map_err(|e| e.to_string())?;
+    let client = ApiClient::new(peer_url, None)?;
     let stmts_hex = stmts_hex.clone();
 
     // spawn a new task for contacting each peer.  Because it is
@@ -647,7 +661,7 @@ pub fn publish_code(
 
 async fn join_all(
   mut tasks: tokio::task::JoinSet<Result<(), String>>,
-) -> Result<(), String> {
+) -> anyhow::Result<()> {
   while let Some(_res) = tasks.join_next().await {}
   Ok(())
 }
@@ -797,10 +811,12 @@ pub fn start_node<C: ProtoComm + 'static>(
   api_config: Option<ApiConfig>,
   comm: C,
   initial_peers: Vec<C::Address>,
-) {
+) -> anyhow::Result<()> {
   eprintln!("Starting Kindelia node...");
   eprintln!("Store path: {:?}", node_config.data_path);
   eprintln!("Network ID: {:#X}", node_config.network_id);
+
+  let addr = comm.get_addr()?;
 
   // Threads
   let mut threads = vec![];
@@ -808,7 +824,6 @@ pub fn start_node<C: ProtoComm + 'static>(
   // Events
   #[cfg(feature = "events")]
   let event_tx = {
-    let addr = comm.get_addr();
     let (event_tx, event_thrds) = spawn_event_handlers(
       node_config.ws.unwrap_or_default(),
       node_config.ui,
@@ -830,6 +845,7 @@ pub fn start_node<C: ProtoComm + 'static>(
   let (node_query_sender, node) = Node::new(
     node_config.data_path,
     node_config.network_id,
+    addr,
     initial_peers,
     comm,
     miner_comm,
@@ -856,20 +872,24 @@ pub fn start_node<C: ProtoComm + 'static>(
   for thread in threads {
     thread.join().unwrap();
   }
+
+  Ok(())
 }
 
 // Shell completion
 // ================
 
 // prints completions for a given shell, eg bash.
-fn print_shell_completions(shell: Shell) -> Result<(), String> {
+fn print_shell_completions(shell: Shell) -> anyhow::Result<()> {
   // obtain name of present executable
   let exec_name = std::env::current_exe()
-    .map_err(|e| format!("Error getting current executable: {}", e))?
+    .map_err(|e| anyhow!(format!("Error getting current executable: {}", e)))?
     .file_name()
-    .ok_or_else(|| "Error getting executable file name".to_string())?
+    .ok_or_else(|| anyhow!("Error getting executable file name".to_string()))?
     .to_str()
-    .ok_or_else(|| "Error decoding executable name as utf8".to_string())?
+    .ok_or_else(|| {
+      anyhow!("Error decoding executable name as utf8".to_string())
+    })?
     .to_string();
 
   // Generates completions for <shell> and prints to stdout

--- a/kindelia/src/main.rs
+++ b/kindelia/src/main.rs
@@ -184,17 +184,15 @@ pub fn run_cli() -> anyhow::Result<()> {
       let skey: String = arg_from_file_or_stdin(secret_file.into())?;
       let skey = skey.trim();
       let skey = hex::decode(skey).map_err(|err| {
-        anyhow!(format!("Secret key should be valid hex string: {}", err))
+        anyhow!("Secret key should be valid hex string: {}", err)
       })?;
-      let skey: [u8; 32] = skey.try_into().map_err(|_| {
-        anyhow!("Secret key should have exactly 64 bytes".to_string())
-      })?;
+      let skey: [u8; 32] = skey
+        .try_into()
+        .map_err(|_| anyhow!("Secret key should have exactly 64 bytes"))?;
       let code = load_code(file, encoded)?;
       let statement = match &code[..] {
         [stmt] => sign_code(stmt, &skey),
-        _ => Err(anyhow!(
-          "Input file should contain exactly one statement".to_string()
-        )),
+        _ => Err(anyhow!("Input file should contain exactly one statement")),
       }?;
       if encoded_output {
         println!("{}", hex::encode(statement.proto_serialized().to_bytes()));
@@ -249,7 +247,7 @@ pub fn run_cli() -> anyhow::Result<()> {
       let network_id = resolve_cfg!(
         env = "KINDELIA_NETWORK_ID",
         prop = "node.network.network_id".to_string(),
-        no_default = anyhow!("Missing `network_id` parameter.".to_string()),
+        no_default = anyhow!("Missing `network_id` parameter."),
         cli_val = network_id,
         cfg = config,
       );
@@ -264,11 +262,8 @@ pub fn run_cli() -> anyhow::Result<()> {
       .join(format!("{:#02X}", network_id));
 
       match command {
-        NodeCommand::Clean { command } => {
-          clean(&data_path, command).map_err(|err| {
-            anyhow!(format!("Could not clean kindelia's data: {}", err))
-          })
-        }
+        NodeCommand::Clean { command } => clean(&data_path, command)
+          .map_err(|err| anyhow!("Could not clean kindelia's data: {}", err)),
         NodeCommand::Start { initial_peers, mine, json } => {
           // TODO: refactor config resolution out of command handling (how?)
 
@@ -337,8 +332,8 @@ pub fn run_cli() -> anyhow::Result<()> {
           .map(|s| s.strip_prefix("0x").unwrap_or(s))
           .map(hex::decode)
           .collect();
-        let data = data
-          .map_err(|err| anyhow!(format!("Invalid hex string: {}", err)))?;
+        let data =
+          data.map_err(|err| anyhow!("Invalid hex string: {}", err))?;
         let nums = data.iter().map(|v| bytes_to_u128(v));
         for num in nums {
           if let Some(num) = num {
@@ -540,7 +535,7 @@ pub fn sign_code(
     | ast::Statement::Run { sign, .. }
     | ast::Statement::Reg { sign, .. } => {
       if sign.is_some() {
-        return Err(anyhow!("Statement already has a signature.".to_string()));
+        return Err(anyhow!("Statement already has a signature."));
       }
     }
   };
@@ -576,11 +571,10 @@ fn statements_from_hex_seq(txt: &str) -> anyhow::Result<Vec<ast::Statement>> {
 }
 
 fn statement_from_hex(hex: &str) -> anyhow::Result<ast::Statement> {
-  let bytes = hex::decode(hex).map_err(|err| {
-    anyhow!(format!("Invalid hexadecimal '{}': {}", hex, err))
-  })?;
+  let bytes = hex::decode(hex)
+    .map_err(|err| anyhow!("Invalid hexadecimal '{}': {}", hex, err))?;
   ast::Statement::proto_deserialized(&bytes_to_bitvec(&bytes))
-    .ok_or_else(|| anyhow!(format!("Failed to deserialize '{}'", hex)))
+    .ok_or_else(|| anyhow!("Failed to deserialize '{}'", hex))
 }
 pub fn publish_code(
   api_url: &str,
@@ -883,13 +877,11 @@ pub fn start_node<C: ProtoComm + 'static>(
 fn print_shell_completions(shell: Shell) -> anyhow::Result<()> {
   // obtain name of present executable
   let exec_name = std::env::current_exe()
-    .map_err(|e| anyhow!(format!("Error getting current executable: {}", e)))?
+    .map_err(|e| anyhow!("Error getting current executable: {}", e))?
     .file_name()
-    .ok_or_else(|| anyhow!("Error getting executable file name".to_string()))?
+    .ok_or_else(|| anyhow!("Error getting executable file name"))?
     .to_str()
-    .ok_or_else(|| {
-      anyhow!("Error decoding executable name as utf8".to_string())
-    })?
+    .ok_or_else(|| anyhow!("Error decoding executable name as utf8"))?
     .to_string();
 
   // Generates completions for <shell> and prints to stdout

--- a/kindelia/src/util.rs
+++ b/kindelia/src/util.rs
@@ -20,9 +20,9 @@ pub fn bytes_to_u128(bytes: &[u8]) -> Option<u128> {
 // Async
 // =====
 
-pub fn run_async_blocking<T, E: ToString, P>(prom: P) -> Result<T, E>
+pub fn run_async_blocking<T, P>(prom: P) -> anyhow::Result<T>
 where
-  P: Future<Output = Result<T, E>>,
+  P: Future<Output = anyhow::Result<T>>,
 {
   let runtime = tokio::runtime::Runtime::new().unwrap();
   runtime.block_on(prom)

--- a/kindelia_core/benches/bench.rs
+++ b/kindelia_core/benches/bench.rs
@@ -9,6 +9,7 @@ use primitive_types::U256;
 
 use kindelia_core::bits::ProtoSerialize;
 use kindelia_core::{constants, runtime, net, node, util};
+use kindelia_core::net::ProtoComm;
 
 // KHVM
 // ====
@@ -150,10 +151,11 @@ fn block_loading(c: &mut Criterion) {
 
   // empty `ProtoComm` to pass the created node
   let comm = net::EmptySocket;
+  let addr = comm.get_addr().unwrap();
 
   // create Node
   let (_, mut node) =
-    node::Node::new(dir.clone(), 0, vec![], comm, None, storage, None);
+    node::Node::new(dir.clone(), 0, addr, vec![], comm, None, storage, None);
 
   // benchmark block loading
   c.bench_function("block_loading", |b| b.iter(|| node.load_blocks()));

--- a/kindelia_core/src/node.rs
+++ b/kindelia_core/src/node.rs
@@ -764,7 +764,7 @@ impl<C: ProtoComm, S: BlockStorage> Node<C, S> {
   pub fn new(
     data_path: PathBuf,
     network_id: u32,
-    addr: C::Address,
+    addr: C::Address,  // todo: review?  https://github.com/Kindelia/Kindelia-Chain/pull/252#discussion_r1037732536
     initial_peers: Vec<C::Address>,
     comm: C,
     miner_comm: Option<MinerCommunication>,

--- a/kindelia_core/src/node.rs
+++ b/kindelia_core/src/node.rs
@@ -760,9 +760,11 @@ pub fn miner_loop(
 // ----
 
 impl<C: ProtoComm, S: BlockStorage> Node<C, S> {
+  #[allow(clippy::too_many_arguments)]
   pub fn new(
     data_path: PathBuf,
     network_id: u32,
+    addr: C::Address,
     initial_peers: Vec<C::Address>,
     comm: C,
     miner_comm: Option<MinerCommunication>,
@@ -784,7 +786,7 @@ impl<C: ProtoComm, S: BlockStorage> Node<C, S> {
     #[rustfmt::skip]
     let mut node = Node {
       network_id,
-      addr: comm.get_addr(),
+      addr,
       comm,
       runtime,
       pool     : PriorityQueue:: new(),

--- a/kindelia_core/src/test/network.rs
+++ b/kindelia_core/src/test/network.rs
@@ -8,7 +8,7 @@ use std::thread;
 use crate::config;
 #[cfg(feature = "events")]
 use crate::events;
-use crate::net::{self, ProtoComm};
+use crate::net::{self, ProtoComm, ProtoCommError};
 use crate::node;
 use crate::{bits, persistence};
 
@@ -103,7 +103,7 @@ fn start_simulation<C: ProtoComm + 'static>(
   initial_peers: Vec<C::Address>,
   tags: Vec<events::NodeEventDiscriminant>,
 ) {
-  let addr = comm.get_addr();
+  let addr = comm.get_addr().unwrap();
 
   // Events
   #[cfg(feature = "events")]
@@ -121,6 +121,7 @@ fn start_simulation<C: ProtoComm + 'static>(
     let (node_query_sender, node) = node::Node::new(
       node_config.data_path,
       node_config.network_id,
+      addr,
       initial_peers,
       comm,
       miner_comm,
@@ -239,8 +240,8 @@ impl net::ProtoComm for SocketMock {
     }
   }
 
-  fn get_addr(&self) -> Self::Address {
-    self.addr
+  fn get_addr(&self) -> Result<Self::Address, ProtoCommError> {
+    Ok(self.addr)
   }
 }
 


### PR DESCRIPTION
Addresses issue #247.  (part a: more to come later)

I started small by just fixing 4 unwrap() calls in kindelia_core/src/net.rs.

Unfortunately one of these involved a trait, which complicated things a bit and required small changes in other files.

In kindelia `main.rs` I could have just mapped the errors from net.rs into a string and submitted a smaller PR, but instead I decided it would be cleaner to handle them as `anyhow::Result`.

I ended up changing most fn in `main.rs` and `config.rs` to return `anyhow::Result` instead of `Result<_, String>`.   This required some calls to `map_err(|e| anyhow!(e)` to deal with `String` errors from `format!()` or from lower level fn calls.  However, as the lower level calls get fixed, then the `map_err` goes away and we will just have `fn_call()?`.   very clean.

note: the map_err() is necessary because `anyhow::Result` accepts `anyhow::Error` which is a boxed dynamic error type that accepts any error type derived from `std::error::Error`.   However `String` is not so derived and thus must be mapped (or preferably return `anyhow::Result` or a thiserror type instead).   

So this is very much a preliminary / intermediate PR to introduce anyhow and show the direction.

I understand there is a big refactor happening in another branch.   I am ok with rebasing onto it when merged.   Or this could be merged first, whichever works.

------

kindelia_core:

* removes all unwrap() from net.rs
* defines error enums in net.rs: ProtoCommError and ParseAddressError
* return Result from affected fn in net.rs
* change IPV6 panic!() to unimplemented!()
* accept addr arg for Node::new() so it can avoid returning Result
* update test and bench as necessary

kindelia:

* add dep on anyhow crate
* return anyhow::Result from config methods
* return anyhow::Result from main methods, including main()
* return anyhow::Result from FileInput::read_to_string()