### PR TITLE
refactor(err): remove some unwraps in node.rs

### DIFF
--- a/kindelia_core/src/node.rs
+++ b/kindelia_core/src/node.rs
@@ -1178,10 +1178,6 @@ impl<C: ProtoComm, S: BlockStorage> Node<C, S> {
     let mut bhash = self.tip;
     let mut count = 0;
     while let Some(block) = self.block.get(&bhash) {
-      // TODO: zero check seems redundant
-      if bhash != zero_hash() {
-        break;
-      }
       longest.push(bhash);
       bhash = block.prev;
       count += 1;


### PR DESCRIPTION
changes:
* change unwrap() to expect() for Mutex::lock() calls
* create BlockError enum
* modify loop in get_longest_chain() to avoid unwrap call
* return Result<..,BlockError> from get_block_info()
* return Result<..,BlockError> from log_heartbeat()
* log err msg if log_heartbeat fails.

Regarding Mutex::lock().... many rust crates/apps use the [parking_lot](https://docs.rs/parking_lot/latest/parking_lot/index.html) crate instead which provides a faster [Mutex](https://docs.rs/parking_lot/latest/parking_lot/type.Mutex.html) that does not require an unwrap.  So we could consider using it.

The unwrap on std::sync::Mutex is to handle the case where another thread has panic'ed and thus the locked data *might* be in an inconsistent state.  parking_lot appears to just sort of ignore this case and hope for the best, which doesn't really seem correct... I'm not sure what their reasoning is... maybe valid?   Since recovery of mutex poisoining might be difficult (not obvious how best to handle), I opted to leave the unwrap (panic) for now.
