### PR TITLE
chore(clippy): fix clippy issues for rustc 1.66.0

### DIFF
--- a/kindelia/src/main.rs
+++ b/kindelia/src/main.rs
@@ -672,7 +672,7 @@ fn init_socket() -> Option<UdpSocket> {
   let try_ports =
     [net::UDP_PORT, net::UDP_PORT + 1, net::UDP_PORT + 2, net::UDP_PORT + 3];
   for port in try_ports {
-    if let Ok(socket) = UdpSocket::bind(&format!("0.0.0.0:{}", port)) {
+    if let Ok(socket) = UdpSocket::bind(format!("0.0.0.0:{}", port)) {
       socket.set_nonblocking(true).ok();
       return Some(socket);
     }

--- a/kindelia/tests/cli.rs
+++ b/kindelia/tests/cli.rs
@@ -143,7 +143,7 @@ mod cli {
       .output()
       .unwrap();
     let output = get_stdout(&output);
-    std::fs::write(&temp_file, &output).unwrap();
+    std::fs::write(&temp_file, output).unwrap();
     let output =
       kindelia!().args(["test", temp_file.to_str().unwrap()]).output().unwrap();
     let output = get_stdout(&output);

--- a/kindelia_core/src/bits.rs
+++ b/kindelia_core/src/bits.rs
@@ -47,7 +47,7 @@ pub fn deserialize_fixlen(
     return None;
   }
   for i in 0..size {
-    let index = (*index + size - i - 1) as usize;
+    let index = *index + size - i - 1;
     result = (result << 1) + bits[index] as u64;
   }
   *index = *index + size;
@@ -64,7 +64,7 @@ pub fn deserialize_fixlen_big(
     return None;
   }
   for i in 0..size {
-    let index = (*index + size - i - 1) as usize;
+    let index = *index + size - i - 1;
     result = (result << 1) + U256::from(bits[index] as u8);
   }
   *index = *index + size;
@@ -86,8 +86,8 @@ pub fn serialize_varlen(value: u128, bits: &mut BitVec) {
 pub fn deserialize_varlen(bits: &BitVec, index: &mut usize) -> Option<u128> {
   let mut val: u128 = 0;
   let mut add: u128 = 1;
-  while bits.get(*index as usize)? {
-    val = val + if bits.get(*index as usize + 1)? { add } else { 0 };
+  while bits.get(*index)? {
+    val = val + if bits.get(*index + 1)? { add } else { 0 };
     add = add << 1;
     *index = *index + 2;
   }
@@ -127,8 +127,8 @@ pub fn deserialize_bits(
   names: &mut Names,
 ) -> Option<BitVec> {
   let mut result = BitVec::new();
-  while bits.get(*index as usize)? {
-    result.push(bits.get(*index as usize + 1)?);
+  while bits.get(*index)? {
+    result.push(bits.get(*index + 1)?);
     *index = *index + 2;
   }
   *index = *index + 1;
@@ -155,7 +155,7 @@ pub fn deserialize_list<T: ProtoSerialize>(
   names: &mut Names,
 ) -> Option<Vec<T>> {
   let mut result = Vec::new();
-  while bits.get(*index as usize)? {
+  while bits.get(*index)? {
     *index = *index + 1;
     result.push(T::proto_deserialize(bits, index, names)?);
   }
@@ -269,14 +269,14 @@ impl ProtoSerialize for Name {
   ) -> Option<Self> {
     let mut nam: u128 = 0;
     let mut add: u128 = 1;
-    let compressed = bits.get(*index as usize)?;
+    let compressed = bits.get(*index)?;
     *index += 1;
     if compressed {
       let id = deserialize_varlen(bits, index)?;
       let nm = *names.get(&id)?;
       Some(Name::from_u128_unchecked(nm))
     } else {
-      while bits.get(*index as usize)? {
+      while bits.get(*index)? {
         *index += 1;
         let got = deserialize_fixlen(6, bits, index)?;
         nam = nam + add * got as u128;
@@ -629,7 +629,7 @@ impl ProtoSerialize for net::Address {
     index: &mut usize,
     _names: &mut Names,
   ) -> Option<net::Address> {
-    if bits[*index as usize] as u128 == 0 {
+    if bits[*index] as u128 == 0 {
       *index = *index + 1;
       let val0 = deserialize_fixlen(8, bits, index)? as u8;
       let val1 = deserialize_fixlen(8, bits, index)? as u8;

--- a/kindelia_core/src/node.rs
+++ b/kindelia_core/src/node.rs
@@ -103,7 +103,7 @@ impl Transaction {
   // Encodes a transaction length as a pair of 2 bytes
   pub fn encode_length(&self) -> (u8, u8) {
     let len = self.data.len() as u16;
-    let num = (len as u16).reverse_bits();
+    let num = len.reverse_bits();
     (((num >> 8) & 0xFF) as u8, (num & 0xFF) as u8)
   }
 
@@ -1253,7 +1253,7 @@ impl<C: ProtoComm, S: BlockStorage> Node<C, S> {
   }
   pub fn get_ctr_info(&self, name: &Name) -> Option<CtrInfo> {
     if let Some(arit) = self.runtime.get_arity(name) {
-      Some(CtrInfo { arit: arit as u64 })
+      Some(CtrInfo { arit })
     } else {
       None
     }

--- a/kindelia_core/src/runtime/mod.rs
+++ b/kindelia_core/src/runtime/mod.rs
@@ -1441,7 +1441,7 @@ impl Runtime {
             Term::num(U120::ZERO)
           };
         self.collect(done);
-        let size_end = self.get_size() as u64;
+        let size_end = self.get_size();
         let mana_dif = self.get_mana() - mana_ini;
         let size_dif = (size_end as i64) - (size_ini as i64);
         if size_end > size_lim && !sudo {
@@ -1484,7 +1484,7 @@ impl Runtime {
 
   // Maximum size = 2048 * block_number
   pub fn get_size_limit(&self) -> u64 {
-    (self.get_tick() as u64 + 1) * (BLOCK_BITS_LIMIT / 128)
+    (self.get_tick() + 1) * (BLOCK_BITS_LIMIT / 128)
   }
 
   // Rollback
@@ -2033,7 +2033,7 @@ pub fn alloc(rt: &mut Runtime, arity: u64) -> Loc {
       // - If less than 50% of the memory is used, jump to a random index and try again
       // - If more than 50% of the memory is used, double the maximum cap and try again
       if rt.get_size() * 2 < mcap {
-        rt.set_next(fastrand::u64(..) % mcap as u64);
+        rt.set_next(fastrand::u64(..) % mcap);
       } else {
         rt.set_mcap(mcap * 2);
       }

--- a/kindelia_core/src/util.rs
+++ b/kindelia_core/src/util.rs
@@ -171,7 +171,7 @@ pub(crate) fn get_time() -> u128 {
   SystemTime::now()
     .duration_since(UNIX_EPOCH)
     .expect("system time should be later than unix epoch")
-    .as_millis() as u128
+    .as_millis()
 }
 
 /// Gets current timestamp in microseconds
@@ -183,7 +183,7 @@ pub(crate) fn get_time_micro() -> u128 {
   std::time::SystemTime::now()
     .duration_since(UNIX_EPOCH)
     .expect("system time should be later than unix epoch")
-    .as_micros() as u128
+    .as_micros()
 }
 
 /// Indicates that the system's time is before the unix epoch
@@ -207,7 +207,7 @@ pub(crate) fn try_get_time() -> Result<u128, EpochError> {
     now
       .duration_since(epoch)
       .map_err(|source| EpochError { now, epoch, source })?
-      .as_millis() as u128,
+      .as_millis(),
   )
 }
 
@@ -219,7 +219,7 @@ pub(crate) fn try_get_time_micro() -> Result<u128, EpochError> {
     now
       .duration_since(epoch)
       .map_err(|source| EpochError { now, epoch, source })?
-      .as_micros() as u128,
+      .as_micros(),
   )
 }
 

--- a/kindelia_server/src/lib.rs
+++ b/kindelia_server/src/lib.rs
@@ -245,7 +245,7 @@ pub async fn api_serve<'a, C: ProtoComm + 'static>(
     async move {
       let functions = ask(query_tx, NodeRequest::get_functions()).await;
       let functions: Vec<u128> =
-        functions.into_iter().map(|x| x as u128).collect();
+        functions.into_iter().collect();
       let functions = u128_names_to_strings(&functions);
       ok_json(functions)
     }


### PR DESCRIPTION
The latest rustc 1.66.0 toolchain issues a bunch of clippy warnings/errors, which CI is [unhappy](https://github.com/Kindelia/Kindelia-Chain/pull/265#issuecomment-1356871065) with.

This fixes that so clippy is happy, eg:

```
$ cd Kindelia

$ cargo --version
cargo 1.66.0 (d65d197ad 2022-11-15)

$ cargo clippy --all-targets --all-features
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
```

edit: `rustfmt` (`cargo fmt`) should also be run over the entire repo and I'm happy to make a PR for that, but there are a bunch of PRs pending, and I think its best to wait until most of those have been merged to avoid some unnecessary conflicts.