### PR TITLE
style(clippy): disallow panics under kindelia/src

### DIFF
--- a/kindelia/src/main.rs
+++ b/kindelia/src/main.rs
@@ -1,3 +1,10 @@
+// High assurance software should not panic.
+// We flip the clippy default to 'warn', so you should think very
+// carefully. If you absolutely cannot avoid it then it has to
+// be explicitly allowed with #[allow(clippy::x)]
+// See https://github.com/Kindelia/Kindelia-Chain/issues/247
+#![warn(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+
 mod cli;
 mod config;
 mod files;


### PR DESCRIPTION
Addressing #247

This causes clippy to emit an error if unwrap, expect, or panic is used in any code invoked by kindelia/src/main.rs

It will therefore cause CI clippy check to fail if these are encountered.

Of course, the code may override with a `#[allow(clippy::unwrap_used)]`.  So this is really just changing the *default* from `allow` to `deny`.

test cases are not affected.  (panics are allowed)

Note that there are [several ways to configure clippy lints](https://stackoverflow.com/a/74545562/10087197).  Once we've removed all the panics that we can, it will probably be best to apply these lints for the entire repo/workspace.  But for now, this seems the simplest, and it applies to only non-test code in the kindelia crate which has already been scrubbed of unwrap, expect, panic.
